### PR TITLE
TAA-229

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ You can also provide custom options:
 
 ```javascript
 const theAuthAPI = new TheAuthAPI("YOUR_ACCESS_KEY", {
-  timeout: 3600,
   retryCount: 2,
 });
 ```
@@ -70,8 +69,6 @@ const theAuthAPI = new TheAuthAPI("YOUR_ACCESS_KEY", {
 type Options = {
   // server url
   host?: string;
-  // request timeout in ms
-  timeout?: string | number;
   // number of retries before failing
   retryCount?: number;
 };
@@ -165,10 +162,12 @@ try {
 ```typescript
 type ApiKeyFilter = {
   projectId?: string;
-  customAccountId?: string;
-  customUserId?: string;
+  name?: string;
+  customAccountId?: string | null;
+  customUserId?: string | null;
   isActive?: boolean;
 };
+
 ```
 
 **Example**: filtering api-keys with a specific `projectId` where the keys are not active

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "theauthapi",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theauthapi",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Client library for TheAuthAPI.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/jest": "^27.4.1",
+    "@types/jest": "^27.5.2",
     "@types/lodash.isstring": "^4.0.6",
     "@types/lodash.omit": "^4.5.6",
     "@types/ms": "^0.7.31",
@@ -51,6 +51,7 @@
     "express": "^4.15.2",
     "jest": "^27.5.1",
     "prettier": "2.6.2",
+    "ts-jest": "^28.0.8",
     "typescript": "^4.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "assert": "^2.0.0",
     "axios": "^0.21.4",
     "axios-retry": "^3.1.9",
-    "lodash.isstring": "^4.0.1",
-    "lodash.omit": "^4.5.0",
-    "ms": "^2.1.3",
     "remove-trailing-slash": "^0.1.1"
   },
   "devDependencies": {

--- a/src/endpoints/Accounts/Accounts.ts
+++ b/src/endpoints/Accounts/Accounts.ts
@@ -2,7 +2,6 @@ import { AccountsInterface } from "./AccountsInterface";
 import ApiRequest from "../../services/ApiRequest/ApiRequest";
 import { Account } from "../../types";
 import { HttpMethod } from "../../services/ApiRequest/HttpMethod";
-import { validateString } from "../../util";
 
 class Accounts implements AccountsInterface {
   api: ApiRequest;
@@ -14,7 +13,6 @@ class Accounts implements AccountsInterface {
   }
 
   async getAccount(accountId: string): Promise<Account> {
-    validateString("accountId", accountId);
     return await this.api.request<Account>(
       HttpMethod.GET,
       `${this.endpoint}/${accountId}`

--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -124,23 +124,32 @@ class ApiKeys implements ApiKeysInterface {
   }
 
   private validateFiltersInput(filter?: ApiKeyFilter) {
-    if (filter) {
-      if (filter.isActive && typeof filter.isActive !== "boolean") {
-        throw TypeError("isActive must be a boolean");
-      }
-      Object.entries(omit(filter, "isActive")).forEach(([key, value]) => {
-        validateString(key, value);
-      });
+    if (!filter) {
+      return;
+    }
+    if (filter.isActive && typeof filter.isActive !== "boolean") {
+      throw TypeError("isActive must be a boolean");
+    }
+    if (filter.customAccountId) {
+      validateString("customAccountId", filter.customAccountId);
+    }
+    if (filter.customUserId) {
+      validateString("customUserId", filter.customUserId);
+    }
+    if (filter.projectId) {
+      validateString("projectId", filter.projectId);
     }
   }
 
   private getKeysFilterEndpoint(filter?: ApiKeyFilter): string {
     this.validateFiltersInput(filter);
     let filters: string[] = [];
-    if (filter) {
+    if (filter !== undefined) {
       filters = Object.entries(filter).map(([key, value]) => `${key}=${value}`);
     }
-    return `${this.endpoint}${filter ? "?" : ""}${filters.join("&")}`;
+    return `${this.endpoint}${filter !== undefined ? "?" : ""}${filters.join(
+      "&"
+    )}`;
   }
 }
 

--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -75,6 +75,14 @@ class ApiKeys implements ApiKeysInterface {
     );
   }
 
+  async reactivateKey(apiKey: string): Promise<ApiKey> {
+    validateString("apiKey", apiKey);
+    return await this.api.request<ApiKey>(
+      HttpMethod.PATCH,
+      `/api-keys/${apiKey}/reactivate`
+    );
+  }
+
   private validateCreateKeyInput(apiKey: ApiKeyInput) {
     if (!apiKey) {
       throw new TypeError("apiKey must be an object");

--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -90,9 +90,20 @@ class ApiKeys implements ApiKeysInterface {
     if (!apiKey.name) {
       throw TypeError("apiKey object must contain the property name");
     }
+    if (apiKey.expiry && !(apiKey.expiry instanceof Date)) {
+      throw TypeError("expiry must be a Date");
+    }
+    if (apiKey.rateLimitConfigs) {
+      if (
+        typeof apiKey.rateLimitConfigs.rateLimit !== "number" ||
+        typeof apiKey.rateLimitConfigs.rateLimitTtl !== "number"
+      ) {
+        throw new TypeError("rateLimitConfigs properties should be a number");
+      }
+    }
     // validate string properties only
     for (const [key, value] of Object.entries(
-      omit(apiKey, ["customMetaData", "rateLimitConfigs"])
+      omit(apiKey, ["customMetaData", "rateLimitConfigs", "expiry"])
     )) {
       validateString(key, value);
     }

--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -21,12 +21,8 @@ class ApiKeys implements ApiKeysInterface {
   }
 
   async isValidKey(apikey: string): Promise<boolean> {
-    validateString("apikey", apikey);
     try {
-      const key = await this.api.request<ApiKey>(
-        HttpMethod.POST,
-        `/api-keys/auth/${apikey}`
-      );
+      const key = await this.authenticateKey(apikey);
       return key.key !== undefined;
     } catch (error) {
       if (error instanceof ApiResponseError && error.statusCode === 404) {

--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -24,7 +24,7 @@ class ApiKeys implements ApiKeysInterface {
     validateString("apikey", apikey);
     try {
       const key = await this.api.request<ApiKey>(
-        HttpMethod.GET,
+        HttpMethod.POST,
         `/api-keys/auth/${apikey}`
       );
       return key.key !== undefined;
@@ -39,7 +39,7 @@ class ApiKeys implements ApiKeysInterface {
   async authenticateKey(apikey: string): Promise<ApiKey> {
     validateString("apikey", apikey);
     return await this.api.request<ApiKey>(
-      HttpMethod.GET,
+      HttpMethod.POST,
       `/api-keys/auth/${apikey}`
     );
   }

--- a/src/endpoints/ApiKeys/ApiKeysInterface.ts
+++ b/src/endpoints/ApiKeys/ApiKeysInterface.ts
@@ -13,4 +13,5 @@ export interface ApiKeysInterface {
   createKey(apiKey: ApiKeyInput): Promise<ApiKey>;
   updateKey(apiKey: string, updateTo: UpdateApiKeyInput): Promise<ApiKey>;
   deleteKey(apiKey: string): Promise<boolean>;
+  reactivateKey(apiKey: string): Promise<ApiKey>;
 }

--- a/src/endpoints/Projects/Projects.ts
+++ b/src/endpoints/Projects/Projects.ts
@@ -1,12 +1,6 @@
 import ApiRequest from "../../services/ApiRequest/ApiRequest";
-import {
-  CreateProjectInput,
-  Environment,
-  Project,
-  UpdateProjectInput,
-} from "../../types";
+import { CreateProjectInput, Project, UpdateProjectInput } from "../../types";
 import { HttpMethod } from "../../services/ApiRequest/HttpMethod";
-import { validateString } from "../../util";
 import { ProjectsInterface } from "./ProjectsInterface";
 
 class Projects implements ProjectsInterface {
@@ -19,7 +13,6 @@ class Projects implements ProjectsInterface {
   }
 
   async getProjects(accountId: string): Promise<Project[]> {
-    validateString("accountId", accountId);
     return await this.api.request<Project[]>(
       HttpMethod.GET,
       `${this.endpoint}?accountId=${accountId}`
@@ -27,7 +20,6 @@ class Projects implements ProjectsInterface {
   }
 
   async getProject(projectId: string): Promise<Project> {
-    validateString("projectId", projectId);
     return await this.api.request<Project>(
       HttpMethod.GET,
       `${this.endpoint}/${projectId}`
@@ -35,7 +27,6 @@ class Projects implements ProjectsInterface {
   }
 
   async deleteProject(projectId: string): Promise<boolean> {
-    validateString("projectId", projectId);
     return await this.api.request<boolean>(
       HttpMethod.DELETE,
       `${this.endpoint}/${projectId}`
@@ -43,7 +34,6 @@ class Projects implements ProjectsInterface {
   }
 
   async createProject(project: CreateProjectInput): Promise<Project> {
-    this.validateCreateProjectInput(project);
     return await this.api.request<Project>(
       HttpMethod.POST,
       this.endpoint,
@@ -55,38 +45,11 @@ class Projects implements ProjectsInterface {
     projectId: string,
     project: UpdateProjectInput
   ): Promise<Project> {
-    this.validateUpdateProjectInput(projectId, project);
     return this.api.request<Project>(
       HttpMethod.PATCH,
       `${this.endpoint}/${projectId}`,
       project
     );
-  }
-
-  private validateCreateProjectInput(project: CreateProjectInput) {
-    if (!project) {
-      throw new TypeError("project must be an object");
-    }
-    validateString("name", project.name);
-    validateString("accountId", project.accountId);
-    if (!Object.values(Environment).includes(project.env)) {
-      throw TypeError(
-        `expected env to be one of [${Object.values(Environment).map(
-          (v) => `"${v}"`
-        )}], got: ${project.env}`
-      );
-    }
-  }
-
-  private validateUpdateProjectInput(
-    projectId: string,
-    project: UpdateProjectInput
-  ) {
-    if (!project) {
-      throw new TypeError("project must be an object");
-    }
-    validateString("projectId", projectId);
-    validateString("name", project.name);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import assert from "assert";
 import removeSlash from "remove-trailing-slash";
 
 import ApiRequest from "./services/ApiRequest/ApiRequest";
-import { validateString } from "./util";
 import ApiKeys from "./endpoints/ApiKeys/ApiKeys";
 import { HttpMethod } from "./services/ApiRequest/HttpMethod";
 import Projects from "./endpoints/Projects/Projects";
@@ -72,8 +71,6 @@ class TheAuthAPI {
     key: string,
     callback?: (err: any, data: any) => any
   ) {
-    validateString("key", key);
-
     const cb = callback || noop;
     const done = (err: any) => {
       cb(err, data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,56 +12,37 @@ const noop = () => {};
 
 type Options = {
   host?: string;
-  timeout?: string | number;
-  cacheTTL?: number;
-  enable?: boolean;
   retryCount?: number;
 };
 
 class TheAuthAPI {
-  queue: [];
   accessKey: string;
   host: string;
   timeout: number | string | undefined;
-  cacheTTL: number;
   api: ApiRequest;
   apiKeys: ApiKeys;
   projects: Projects;
   accounts: Accounts;
 
   /**
-   * Initialize a new `Analytics` with your Segment project's `writeKey` and an
-   * optional dictionary of `options`.
-   *
    * @param {String} accessKey
    * @param {Object} [options] (optional)
-   *   @property {Number} flushAt (default: 20)
-   *   @property {Number} flushInterval (default: 10000)
    *   @property {String} host (default: 'https://api.segment.io')
-   *   @property {Boolean} enable (default: true)
+   *   @property {number} retryCount (default: 3)
    */
 
   constructor(accessKey: string, options?: Options) {
     assert(accessKey, "You must pass your project's write key.");
-    this.queue = [];
     this.accessKey = accessKey;
     this.host = removeSlash(options?.host || "https://api.theauthapi.com");
-    this.timeout = options?.timeout;
-    this.cacheTTL = options?.cacheTTL ?? 60;
     this.api = new ApiRequest({
       accessKey: this.accessKey,
       host: this.host,
+      retryCount: options?.retryCount ?? 3,
     });
     this.apiKeys = new ApiKeys(this.api);
     this.projects = new Projects(this.api);
     this.accounts = new Accounts(this.api);
-
-    Object.defineProperty(this, "enable", {
-      configurable: false,
-      writable: false,
-      enumerable: true,
-      value: typeof options?.enable === "boolean" ? options.enable : true,
-    });
   }
 
   /*

--- a/src/libraryMeta.ts
+++ b/src/libraryMeta.ts
@@ -1,1 +1,1 @@
-export const version = "1.0.10";
+export const version = "1.0.11";

--- a/src/services/ApiRequest/ApiRequest.ts
+++ b/src/services/ApiRequest/ApiRequest.ts
@@ -12,22 +12,19 @@ type Config = {
   accessKey: string;
   headers?: object;
   retryCount?: number;
-  timeout?: number | string;
 };
 
 class ApiRequest implements ApiCall {
   host: string;
   headers: object;
   accessKey: string;
-  timeout: number;
   retryCount: number;
 
   constructor(config: Config) {
-    const { host, accessKey, headers, retryCount, timeout } = config;
+    const { host, accessKey, headers, retryCount } = config;
     this.host = host;
     this.accessKey = accessKey;
     this.headers = this._generateDefaultHeaders();
-    this.timeout = timeout ? (typeof timeout === "string" ? ms(timeout) : timeout) : 0;
     this.retryCount = retryCount ?? 3;
 
     if (headers) {
@@ -38,12 +35,13 @@ class ApiRequest implements ApiCall {
   }
 
   _init() {
-    const isoDateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d*)?(?:[-+]\d{2}:?\d{2}|Z)?$/
+    const isoDateFormat =
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d*)?(?:[-+]\d{2}:?\d{2}|Z)?$/;
     function isIsoDateString(value: any): boolean {
       return value && typeof value === "string" && isoDateFormat.test(value);
     }
     function handleDates(body: any) {
-      if (body === null || body === undefined || typeof body !== "object"){
+      if (body === null || body === undefined || typeof body !== "object") {
         return body;
       }
       for (const key of Object.keys(body)) {

--- a/src/tests/endpoints/accounts.spec.ts
+++ b/src/tests/endpoints/accounts.spec.ts
@@ -1,7 +1,6 @@
 import TheAuthAPI from "../../index";
 import { Server } from "http";
 import testServer from "../testServer/server";
-import { shouldThrowTypeError } from "../util";
 
 const port = 4063;
 
@@ -40,9 +39,4 @@ describe("Accounts", () => {
       })
     );
   });
-
-  it("should validate parameter types", async () => {
-    const client = createClient();
-    await shouldThrowTypeError(() => client.accounts.getAccount(undefined as any));
-  })
 });

--- a/src/tests/endpoints/apiKeys.spec.ts
+++ b/src/tests/endpoints/apiKeys.spec.ts
@@ -1,7 +1,7 @@
 import TheAuthAPI from "../../index";
 import testServer from "../testServer/server";
 import { Server } from "http";
-import { shouldThrowError, shouldThrowTypeError } from "../util";
+import { shouldThrowError } from "../util";
 import ApiResponseError from "../../services/ApiRequest/ApiResponseError";
 import ApiKeys from "../../endpoints/ApiKeys/ApiKeys";
 
@@ -296,103 +296,5 @@ describe("ApiKeys", () => {
     ).toEqual(
       "/api-keys/?projectId=123&customUserId=USR1&customAccountId=ACC1&isActive=true"
     );
-  });
-
-  it("should validate parameter types", async () => {
-    const client = createClient();
-    await shouldThrowTypeError(() =>
-      client.apiKeys.isValidKey(undefined as any)
-    );
-    await shouldThrowTypeError(() => client.apiKeys.getKey(undefined as any));
-    await shouldThrowTypeError(() =>
-      client.apiKeys.deleteKey(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({ projectId: "1" } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        key: undefined,
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        customAccountId: undefined,
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        customUserId: undefined,
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        customUserId: undefined,
-        rateLimitConfigs: {
-          rateLimit: "1",
-          rateLimitTtl: 123,
-        },
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        customUserId: undefined,
-        rateLimitConfigs: {
-          rateLimit: 123,
-          rateLimitTtl: "1",
-        },
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.createKey({
-        name: "a",
-        projectId: "1",
-        expiry: "not a date",
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.updateKey(undefined as any, {} as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.apiKeys.updateKey(
-        undefined as any,
-        { name: "a", customAccountId: undefined } as any
-      )
-    );
-  });
-
-  it("should validate query filters", () => {
-    const client = createClient();
-    const apiKeys = client.apiKeys;
-    expect(() =>
-      apiKeys["getKeysFilterEndpoint"]({ isActive: 1 as any })
-    ).toThrow(TypeError);
-    expect(() =>
-      apiKeys["getKeysFilterEndpoint"]({
-        customUserId: 1 as any,
-        isActive: false,
-      })
-    ).toThrow(TypeError);
-    expect(() =>
-      apiKeys["getKeysFilterEndpoint"]({
-        customAccountId: 1 as any,
-      })
-    ).toThrow(TypeError);
-    expect(() =>
-      apiKeys["getKeysFilterEndpoint"]({ projectId: 1 as any })
-    ).toThrow(TypeError);
   });
 });

--- a/src/tests/endpoints/apiKeys.spec.ts
+++ b/src/tests/endpoints/apiKeys.spec.ts
@@ -200,6 +200,17 @@ describe("ApiKeys", () => {
     expect(response).toBeTruthy();
   });
 
+  it("should reactivate a key", async () => {
+    const client = createClient();
+    const key = await client.apiKeys.reactivateKey(
+      "live_TVHW0PVtktylIVObMd8J0sBHb7Ym3ZraObpeT3qxu7YRHig2KxrEIwggn50sBpSZ"
+    );
+    expect(key.name).toEqual("my-first-api-key");
+    expect(key.key).toEqual(
+      "live_h3uDZInxQexGLkwoxMDmuqz6PsyXGjkbrmSTpEwFb8l97mdAlQKtt14kt9Rv91PL"
+    );
+  });
+
   it("getKeysFilterEndpoint", async () => {
     const client = createClient();
     const apiKeys = client.apiKeys;

--- a/src/tests/endpoints/apiKeys.spec.ts
+++ b/src/tests/endpoints/apiKeys.spec.ts
@@ -270,6 +270,35 @@ describe("ApiKeys", () => {
       } as any)
     );
     await shouldThrowTypeError(() =>
+      client.apiKeys.createKey({
+        name: "a",
+        projectId: "1",
+        customUserId: undefined,
+        rateLimitConfigs: {
+          rateLimit: "1",
+          rateLimitTtl: 123,
+        },
+      } as any)
+    );
+    await shouldThrowTypeError(() =>
+      client.apiKeys.createKey({
+        name: "a",
+        projectId: "1",
+        customUserId: undefined,
+        rateLimitConfigs: {
+          rateLimit: 123,
+          rateLimitTtl: "1",
+        },
+      } as any)
+    );
+    await shouldThrowTypeError(() =>
+      client.apiKeys.createKey({
+        name: "a",
+        projectId: "1",
+        expiry: "not a date",
+      } as any)
+    );
+    await shouldThrowTypeError(() =>
       client.apiKeys.updateKey(undefined as any, {} as any)
     );
     await shouldThrowTypeError(() =>

--- a/src/tests/endpoints/apiKeys.spec.ts
+++ b/src/tests/endpoints/apiKeys.spec.ts
@@ -140,6 +140,50 @@ describe("ApiKeys", () => {
     );
   });
 
+  it("should filter api keys using customUserId", async () => {
+    const client = createClient();
+    const keys = await client.apiKeys.getKeys({
+      projectId: "b52262b5-eaa6-4edd-825c-ebcdf76a10e5",
+      customUserId: null,
+    });
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "KGTSsxbDndjRRcpJGuQQp2or9UmQkqRrVQpCWgQruIXnvnNatmfdmOTcsgYnNwnH",
+          name: "My customers first Api Key",
+          customMetaData: {},
+          customAccountId: "acc-id",
+          customUserId: null,
+          env: "live",
+          createdAt: new Date("2022-03-16T10:34:23.353Z"),
+          updatedAt: new Date("2022-03-16T10:34:23.353Z"),
+          isActive: true,
+        }),
+      ])
+    );
+  });
+
+  it("should filter api keys using customAccountId", async () => {
+    const client = createClient();
+    const keys = await client.apiKeys.getKeys({
+      projectId: "b52262b5-eaa6-4edd-825c-ebcdf76a10e5",
+      customAccountId: null,
+    });
+    expect(keys).toEqual([
+      {
+        key: "live_h3uDZInxQexGLkwoxMDmuqz6PsyXGjkbrmSTpEwFb8l97mdAlQKtt14kt9Rv91PL",
+        name: "my-first-api-key",
+        customMetaData: {},
+        customAccountId: null,
+        customUserId: "USR123",
+        env: "live",
+        createdAt: new Date("2022-04-03T01:59:32.051Z"),
+        updatedAt: new Date("2022-04-03T01:59:32.051Z"),
+        isActive: true,
+      },
+    ]);
+  });
+
   it("should create a key", async () => {
     const client = createClient();
     const key = await client.apiKeys.createKey({

--- a/src/tests/endpoints/apiKeys.spec.ts
+++ b/src/tests/endpoints/apiKeys.spec.ts
@@ -163,6 +163,27 @@ describe("ApiKeys", () => {
     );
   });
 
+  it("should filter api keys using name", async () => {
+    const client = createClient();
+    const keys = await client.apiKeys.getKeys({
+      projectId: "b52262b5-eaa6-4edd-825c-ebcdf76a10e5",
+      name: "my-first-api-key",
+    });
+    expect(keys).toEqual([
+      {
+        key: "live_h3uDZInxQexGLkwoxMDmuqz6PsyXGjkbrmSTpEwFb8l97mdAlQKtt14kt9Rv91PL",
+        name: "my-first-api-key",
+        customMetaData: {},
+        customAccountId: null,
+        customUserId: "USR123",
+        env: "live",
+        createdAt: new Date("2022-04-03T01:59:32.051Z"),
+        updatedAt: new Date("2022-04-03T01:59:32.051Z"),
+        isActive: true,
+      },
+    ]);
+  });
+
   it("should filter api keys using customAccountId", async () => {
     const client = createClient();
     const keys = await client.apiKeys.getKeys({

--- a/src/tests/endpoints/projects.spec.ts
+++ b/src/tests/endpoints/projects.spec.ts
@@ -1,7 +1,6 @@
 import TheAuthAPI from "../../index";
 import testServer from "../testServer/server";
 import { Server } from "http";
-import { shouldThrowTypeError } from "../util";
 import { Environment } from "../../types";
 
 const port = 4063;
@@ -103,58 +102,6 @@ describe("Projects", () => {
         accountId: "my-account-id",
         env: "live",
       })
-    );
-  });
-
-  it("should validate parameter types", async () => {
-    const client = createClient();
-    await shouldThrowTypeError(() =>
-      client.projects.getProjects(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.getProject(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.deleteProject(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.createProject(undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.createProject({
-        name: "name",
-        accountId: "account",
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.createProject({
-        name: "name",
-        env: Environment.LIVE,
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.createProject({
-        accountId: "account",
-        env: Environment.LIVE,
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.createProject({
-        name: "name",
-        accountId: "account",
-        env: "unknown",
-      } as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.updateProject(undefined as any, {
-        name: "name",
-      })
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.updateProject("project", undefined as any)
-    );
-    await shouldThrowTypeError(() =>
-      client.projects.updateProject("project", {} as any)
     );
   });
 });

--- a/src/tests/testServer/routes/apiKeys.ts
+++ b/src/tests/testServer/routes/apiKeys.ts
@@ -148,6 +148,15 @@ export const apiKeyRoutes = router
     }
     return response.json({ ...keys[1], name });
   })
+  .patch("/:key/reactivate", (request, response) => {
+    const { key } = request.params;
+    if (!key) {
+      return response.status(400).json({
+        message: "missing api-key",
+      });
+    }
+    return response.json(keys[1]);
+  })
   .delete("/:key", (request, response) => {
     const { key } = request.params;
     if (!key) {

--- a/src/tests/testServer/routes/apiKeys.ts
+++ b/src/tests/testServer/routes/apiKeys.ts
@@ -92,7 +92,10 @@ export const apiKeyRoutes = router
       return response.json(keys.slice(1));
     }
     const filtered = keys.filter((key) => {
-      if (isActive && key.isActive !== (isActive === "true")) {
+      if (
+        (isActive && key.isActive !== (isActive === "true")) ||
+        !key.isActive
+      ) {
         return false;
       }
       if (

--- a/src/tests/testServer/routes/apiKeys.ts
+++ b/src/tests/testServer/routes/apiKeys.ts
@@ -39,7 +39,7 @@ const keys = [
 ];
 
 export const apiKeyRoutes = router
-  .get("/auth/:key", (request, response) => {
+  .post("/auth/:key", (request, response) => {
     const key = request.params.key;
     if (!key) {
       return response.status(400).json({

--- a/src/tests/testServer/routes/apiKeys.ts
+++ b/src/tests/testServer/routes/apiKeys.ts
@@ -84,7 +84,7 @@ export const apiKeyRoutes = router
     return response.json(keys[0]);
   })
   .get("/", (request, response) => {
-    const { projectId, isActive, customAccountId, customUserId } =
+    const { projectId, isActive, customAccountId, customUserId, name } =
       request.query;
 
     if (!projectId) {
@@ -109,6 +109,9 @@ export const apiKeyRoutes = router
         key.customAccountId !==
           (customAccountId === "null" ? null : customAccountId)
       ) {
+        return false;
+      }
+      if (name && key.name.toLowerCase() !== (name as string).toLowerCase()) {
         return false;
       }
       return true;

--- a/src/tests/util.ts
+++ b/src/tests/util.ts
@@ -1,15 +1,6 @@
-export async function shouldThrowError(
-  cb: any,
-  errorType: any = Error,
-) {
+export async function shouldThrowError(cb: any, errorType: any = Error) {
   async function action(cb: (...args: any) => any) {
     await cb();
   }
   await expect(action(cb as any)).rejects.toThrow(errorType);
-}
-
-export async function shouldThrowTypeError(
-  cb: any,
-) {
-  await shouldThrowError(cb, TypeError);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,8 +37,12 @@ export type ApiKeyFilter = {
 
 export type UpdateApiKeyInput = {
   name: string;
+  key?: string;
   customMetaData?: AnyJson;
   customAccountId?: string;
+  customUserId?: string;
+  expiry?: Date | null;
+  rateLimitConfigs?: RateLimitConfiguration | null;
 };
 
 export enum AuthedEntityType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export type ApiKey = {
   key: string;
   name: string;
-  customMetaData: object;
+  customMetaData: AnyJson;
   customAccountId: string;
   customUserId: string;
   env: Environment;
@@ -21,11 +21,11 @@ export type ApiKeyInput = {
   name: string;
   projectId?: string;
   key?: string;
-  customMetaData?: object;
+  customMetaData?: AnyJson;
   customAccountId?: string;
   customUserId?: string;
   rateLimitConfigs?: RateLimitConfiguration;
-  expiry?: Date,
+  expiry?: Date;
 };
 
 export type ApiKeyFilter = {
@@ -37,7 +37,7 @@ export type ApiKeyFilter = {
 
 export type UpdateApiKeyInput = {
   name: string;
-  customMetaData?: object;
+  customMetaData?: AnyJson;
   customAccountId?: string;
 };
 
@@ -83,3 +83,9 @@ export type Account = AuthBaseEntity & {
   id: string;
   name: string;
 };
+
+type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
+type JsonMap = {
+  [key: string]: AnyJson;
+};
+type JsonArray = Array<AnyJson>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export type ApiKeyInput = {
 
 export type ApiKeyFilter = {
   projectId?: string;
+  name?: string;
   customAccountId?: string | null;
   customUserId?: string | null;
   isActive?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,8 +30,8 @@ export type ApiKeyInput = {
 
 export type ApiKeyFilter = {
   projectId?: string;
-  customAccountId?: string;
-  customUserId?: string;
+  customAccountId?: string | null;
+  customUserId?: string | null;
   isActive?: boolean;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export type ApiKeyInput = {
   customAccountId?: string;
   customUserId?: string;
   rateLimitConfigs?: RateLimitConfiguration;
+  expiry?: Date,
 };
 
 export type ApiKeyFilter = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,11 +8,11 @@ export type ApiKey = {
   createdAt: Date;
   updatedAt: Date;
   isActive: boolean;
+  rateLimitConfigs: RateLimitConfiguration;
+  expiry: Date;
 };
 
 export type RateLimitConfiguration = {
-  rateLimitedEntity?: string;
-  ratelimitedEnitityId?: string;
   rateLimit: number;
   rateLimitTtl: number;
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,7 +1,0 @@
-import isString from "lodash.isstring";
-
-export function validateString(variableName: string, value: string) {
-    if (!value || !isString(value)) {
-      throw new TypeError(`${variableName} must be a string, got: ${value}`);
-    }
-}


### PR DESCRIPTION
- Use `POST` instead of `GET` to authenticate a key
- add method for `PATCH ./api-keys/:key/reactivate`
- Update Types to match latest ones in the API
- Allow filtering API keys by null for (`customerUserId`, `customAccountId`). Add filter key by name
- Removes runtime validation
- Removes unused options/configs