### PR TITLE
feat: support domain locking

### DIFF
--- a/src/endpoints/ApiKeys/ApiKeys.ts
+++ b/src/endpoints/ApiKeys/ApiKeys.ts
@@ -18,9 +18,9 @@ class ApiKeys implements ApiKeysInterface {
     this.endpoint = '/api-keys/';
   }
 
-  async isValidKey(apikey: string): Promise<boolean> {
+  async isValidKey(apikey: string, origin?: string): Promise<boolean> {
     try {
-      const key = await this.authenticateKey(apikey);
+      const key = await this.authenticateKey(apikey, origin);
       return key.key !== undefined;
     } catch (error) {
       if (error instanceof ApiResponseError && error.statusCode === 404) {
@@ -30,10 +30,13 @@ class ApiKeys implements ApiKeysInterface {
     }
   }
 
-  async authenticateKey(apikey: string): Promise<ApiKey> {
+  async authenticateKey(apikey: string, origin?: string): Promise<ApiKey> {
+    const additionalHeaders = origin ? { 'x-origin-domain': origin } : undefined;
     return await this.api.request<ApiKey>(
       HttpMethod.POST,
       `/api-keys/auth/${apikey}`,
+      undefined,
+      additionalHeaders,
     );
   }
 

--- a/src/endpoints/ApiKeys/ApiKeysInterface.ts
+++ b/src/endpoints/ApiKeys/ApiKeysInterface.ts
@@ -6,9 +6,9 @@ import {
 } from '../../types';
 
 export interface ApiKeysInterface {
-  isValidKey(apiKey: string): Promise<boolean>;
+  isValidKey(apiKey: string, origin?: string): Promise<boolean>;
   getKey(apiKey: string): Promise<ApiKey>;
-  authenticateKey(apiKey: string): Promise<ApiKey>;
+  authenticateKey(apiKey: string, origin?: string): Promise<ApiKey>;
   getKeys(filter?: ApiKeyFilter): Promise<ApiKey[]>;
   createKey(apiKey: ApiKeyInput): Promise<ApiKey>;
   updateKey(apiKey: string, updateTo: UpdateApiKeyInput): Promise<ApiKey>;

--- a/src/services/ApiRequest/ApiRequest.ts
+++ b/src/services/ApiRequest/ApiRequest.ts
@@ -70,6 +70,7 @@ class ApiRequest implements ApiCall {
     method: HttpMethod,
     endpoint: string,
     payload?: any,
+    additionalHeaders?: Record<string, string>,
   ): Promise<T> {
     try {
       const response = await axios.request<T>({
@@ -77,7 +78,7 @@ class ApiRequest implements ApiCall {
         method: method,
         url: endpoint,
         data: payload,
-        headers: this.headers,
+        headers: { ...this.headers, ...additionalHeaders },
       });
       return response.data;
     } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export type ApiKey = {
   isActive: boolean;
   rateLimitConfigs: RateLimitConfiguration;
   expiry: Date;
+  allowedDomains?: string[];
 };
 
 export type RateLimitConfiguration = {
@@ -26,6 +27,7 @@ export type ApiKeyInput = {
   customUserId?: string;
   rateLimitConfigs?: RateLimitConfiguration;
   expiry?: Date;
+  allowedDomains?: string[];
 };
 
 export type ApiKeyFilter = {
@@ -44,6 +46,7 @@ export type UpdateApiKeyInput = {
   customUserId?: string;
   expiry?: Date | null;
   rateLimitConfigs?: RateLimitConfiguration | null;
+  allowedDomains?: string[] | null;
 };
 
 export enum AuthedEntityType {


### PR DESCRIPTION
Updates the Node library to support domain locking by accepting an optional origin parameter in isValidKey and authenticateKey, forwarding it in the x-origin-domain header.